### PR TITLE
[DOC]: Update readme to show marker id usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,15 @@ batch = torch.randn(batch_size, marker_count, patch_size, patch_size).to(device)
 # see marker_metadata.csv for actual mean and std values for each marker ids
 mean = torch.randn(marker_count).to(device)
 std = torch.randn(marker_count).to(device)
+# generate dummy marker ids, see marker_metadata.csv for the actual marker ids.
+marker_ids = torch.randint(4, 512, (batch_size, marker_count), dtype=torch.int64).to(device)
 
 # normalizing the batch
 batch = (batch - mean[None, :, None, None]) / std[None, :, None, None]
 
 # feature extraction
 with torch.no_grad():
-    patch_embeddings, marker_embeddings, token_embeddings = model(batch)
+    patch_embeddings, marker_embeddings, token_embeddings = model(batch, marker_ids=marker_ids)
 
 print(f'Patch embeddings: {patch_embeddings.shape}')
 print(f'Marker embeddings: {marker_embeddings.shape}')


### PR DESCRIPTION
Hi, code example in the `README.md` is not clear about the usage of the marker id during the model inference (Empty argument works also, it is assigned a marker_id according to the channel index. This might not match the actual marker id that corresponds to the marker name).

This PR updates the example such that it is more clear about the significance and usage of marker id during model inference. 

Best,